### PR TITLE
removing read from connection after we have already read the OK respo…

### DIFF
--- a/sonic/ingester.go
+++ b/sonic/ingester.go
@@ -100,11 +100,11 @@ func NewIngester(host string, port int, password string) (Ingestable, error) {
 func (i ingesterChannel) Push(collection, bucket, object, text string) (err error) {
 	//
 	patterns := []struct {
-		Pattern string
-		Replacement     string
+		Pattern     string
+		Replacement string
 	}{{"\\", "\\\\"},
 		{"\n", "\\n"},
-		{"\"",  "\\\""}}
+		{"\"", "\\\""}}
 	for _, v := range patterns {
 		text = strings.Replace(text, v.Pattern, v.Replacement, -1)
 	}
@@ -175,11 +175,6 @@ func (i ingesterChannel) BulkPush(collection, bucket string, parallelRoutines in
 				if err != nil {
 					addBulkError(&errs, rec, err, errMutex)
 					continue
-				}
-				// sonic should sent OK
-				_, err = conn.read()
-				if err != nil {
-					addBulkError(&errs, rec, err, errMutex)
 				}
 			}
 			conn.close()


### PR DESCRIPTION
removing redundant call to read from the connection after we already have the 'OK' from sonic in the call to push.

This should close issue: https://github.com/expectedsh/go-sonic/issues/9